### PR TITLE
Unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,12 @@ RUN apk upgrade --update && \
            /root/.cabal \
            /root/.ghc && \
     set -x && \
-    addgroup -g 82 -S www-data && \
-    adduser -u 82 -D -S -G www-data www-data && \
+    addgroup -g 82 -S pandoc && \
+    adduser -u 82 -D -S -G pandoc pandoc && \
     apk del .build-deps
 
 # Set to non root user
-USER www-data
+USER pandoc
 
 # Reset the work dir
 WORKDIR /var/docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apk upgrade --update && \
     apk add --virtual .build-deps $BUILD_DEPS && \
     apk add --virtual .persistent-deps $PERSISTENT_DEPS && \
     curl -fsSL "$PLANTUML_DOWNLOAD_URL" -o /usr/local/plantuml.jar && \
+    chmod a+r /usr/local/plantuml.jar && \
     mkdir -p /pandoc-build \
              /var/docs && \
     cd /pandoc-build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ RUN apk upgrade --update && \
     adduser -u 82 -D -S -G pandoc pandoc && \
     apk del .build-deps
 
+COPY plantuml /usr/local/bin/
+
 # Set to non root user
 USER pandoc
 

--- a/plantuml
+++ b/plantuml
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/java -jar '/usr/local/plantuml.jar' "$@"


### PR DESCRIPTION
Currently, the image includes steps to add an unprivileged user called `www-data`. But at the same time, the sample Dockerfile in the README includes the `USER root` instruction, which then sidesteps this unprivileged user. While playing around with the image, I found that the unprivileged user doesn't have access to the PlantUML JAR, because it is only readable by the root user. Furthermore, tools like [this Pandoc filter](https://aur.archlinux.org/cgit/aur.git/tree/plantuml.run?h=plantuml) expect a separate `plantuml` executable, which isn't included at the moment.

Merging this will:
1. Add a command to make the downloaded `plantuml.jar` accessible by unprivileged users (not just root);
1. Add & include the `plantuml` executable (adapted from [this AUR package](https://aur.archlinux.org/cgit/aur.git/tree/plantuml.run?h=plantuml)).
1. Rename the unprivileged user to `pandoc`.

Again, feel free to cherry-pick if you want. Or let me know what you think and I can adapt & rebase. I'm not too fussed about the name of the unprivileged user, just thought `pandoc` made more sense than `www-data`.