### PR TITLE
Drop references to Sphinx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 #
 # We use:
 # * Pandoc (Haskell) to convert all Markdown into either generated HTML or .rst files.
-# * Sphinx (Python) to convert .rst files into generated HTML.
 # * PlantUML (Java) to convert UML diagrams to SVG images.
 #
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ![MicroBadger Size (tag)](https://img.shields.io/microbadger/image-size/skyzyx/alpine-pandoc/1.1.0?style=for-the-badge) ![MicroBadger Layers (tag)](https://img.shields.io/microbadger/layers/skyzyx/alpine-pandoc/1.1.0?style=for-the-badge) ![Docker Pulls](https://img.shields.io/docker/pulls/skyzyx/alpine-pandoc?style=for-the-badge) ![Docker Stars](https://img.shields.io/docker/stars/skyzyx/alpine-pandoc?style=for-the-badge)
 
-This is the source code which builds a Docker container comprised of Alpine Linux, [Pandoc], [PlantUML], and [Sphinx]. It is intended to provide an environment which is optimized for generating documentation.
+This is the source code which builds a Docker container comprised of Alpine Linux, [Pandoc], and [PlantUML].
+It is intended to provide an environment which is optimized for generating documentation.
 
 We use:
 
 * [Pandoc] (Haskell) to convert all [Markdown] into either generated HTML or [reStructuredText] files.
-* [Sphinx] (Python) to convert [reStructuredText] files into generated HTML.
 * [PlantUML] (Java) to convert UML diagrams to SVG images.
 
 ## Building the Container
@@ -32,7 +32,7 @@ The short version is `FROM skyzyx/alpine-pandoc:1.1.0`.
 ```Dockerfile
 FROM skyzyx/alpine-pandoc:1.1.0
 
-ENV PERSISTENT_DEPS wget git mercurial make gmp openssh
+ENV PERSISTENT_DEPS wget git mercurial make gmp openssh sphinx
 ENV SPHINXBUILD /usr/bin/sphinx-build
 ENV SPHINXOPTS -T
 
@@ -66,4 +66,3 @@ services:
   [Pandoc]: http://pandoc.org
   [PlantUML]: http://plantuml.com
   [reStructuredText]: http://docutils.sourceforge.net/rst.html
-  [Sphinx]: http://www.sphinx-doc.org


### PR DESCRIPTION
The README contains multiple references to Spinx, but as far as I can tell, it is not actually included in the image. There is no `RUN apk add sphinx` instruction, and consequently `which sphinx` comes up empty.

Merging this will:
1. Remove most references to Spinx in `README.md` and `Dockerfile`;
1. Extend the example `Dockerfile` in the README to install sphinx.