### PR TITLE
Drop Pandoc `lib` folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN apk upgrade --update && \
     cabal copy && \
     cd / && \
     rm -Rf /pandoc-build \
+           $PANDOC_ROOT/lib \
            /root/.cabal \
            /root/.ghc && \
     set -x && \


### PR DESCRIPTION
Building Pandoc using cabal generates three folders: `bin/`, `lib/` and `share/`. While `bin/` and `share/` are definitely needed, I've found that `lib/` can be deleted without breaking Pandoc.

Merging this will:
1. Add a command to remove Pandoc's `lib/` folder from the image.

This should shave off just over 100MB from the image! :smile: 