### PR TITLE
Extend readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Subsequent runs of `docker-compose up` will only execute your `ENTRYPOINT` task.
 
 ### Sample `Dockerfile`
 
+#### Using [Sphinx]
+
 ```Dockerfile
 FROM skyzyx/alpine-pandoc:1.2.0
 
@@ -52,6 +54,28 @@ RUN pip install -r requirements.txt
 ENTRYPOINT ["make", "docs"]
 ```
 
+#### Using [XeTeX] and [pandoc-plantuml-filter]
+
+```Dockerfile
+FROM skyzyx/alpine-pandoc:1.2.0
+
+USER root
+ENV DEPS \
+    make \
+    texlive-xetex
+RUN apk add --no-cache $DEPS && \
+    pip install pandoc-plantuml-filter
+
+USER pandoc
+ENTRYPOINT ["make", "docs"]
+
+# make ultimately calls:
+#  pandoc --filter=pandoc-plantuml
+#         --output=out.pdf
+#         --from=markdown
+#         *.md
+```
+
 ### Sample `docker-compose.yml`
 
 ```yaml
@@ -68,5 +92,8 @@ services:
 [Docker Compose]: https://docs.docker.com/compose/
 [Markdown]: http://commonmark.org
 [Pandoc]: http://pandoc.org
+[pandoc-plantuml-filter]: https://github.com/timofurrer/pandoc-plantuml-filter
 [PlantUML]: http://plantuml.com
 [reStructuredText]: http://docutils.sourceforge.net/rst.html
+[Sphinx]: http://www.sphinx-doc.org
+[XeTeX]: http://xetex.sourceforge.net/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Subsequent runs of `docker-compose up` will only execute your `ENTRYPOINT` task.
 ```Dockerfile
 FROM skyzyx/alpine-pandoc:1.2.0
 
-ENV PERSISTENT_DEPS wget git mercurial make gmp openssh sphinx
+ENV PERSISTENT_DEPS wget git mercurial make openssh sphinx
 ENV SPHINXBUILD /usr/bin/sphinx-build
 ENV SPHINXOPTS -T
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # alpine-pandoc
 
-![MicroBadger Size (tag)](https://img.shields.io/microbadger/image-size/skyzyx/alpine-pandoc/1.1.0?style=for-the-badge) ![MicroBadger Layers (tag)](https://img.shields.io/microbadger/layers/skyzyx/alpine-pandoc/1.1.0?style=for-the-badge) ![Docker Pulls](https://img.shields.io/docker/pulls/skyzyx/alpine-pandoc?style=for-the-badge) ![Docker Stars](https://img.shields.io/docker/stars/skyzyx/alpine-pandoc?style=for-the-badge)
+![MicroBadger Size (tag)](https://img.shields.io/microbadger/image-size/skyzyx/alpine-pandoc/1.1.0?style=for-the-badge)
+![MicroBadger Layers (tag)](https://img.shields.io/microbadger/layers/skyzyx/alpine-pandoc/1.1.0?style=for-the-badge)
+![Docker Pulls](https://img.shields.io/docker/pulls/skyzyx/alpine-pandoc?style=for-the-badge)
+![Docker Stars](https://img.shields.io/docker/stars/skyzyx/alpine-pandoc?style=for-the-badge)
 
 This is the source code which builds a Docker container comprised of Alpine Linux, [Pandoc], and [PlantUML].
 It is intended to provide an environment which is optimized for generating documentation.
@@ -25,7 +28,8 @@ The short version is `FROM skyzyx/alpine-pandoc:1.1.0`.
 1. Use something like [Docker Compose] to mount your documentation source to `/var/docs`.
 1. Add your documentation-building task as an `ENTRYPOINT`.
 
-`docker-compose up` the first time (or with `--build`) will build your custom container, then run your `ENTRYPOINT` task. Subsequent runs of `docker-compose up` will only execute your `ENTRYPOINT` task.
+`docker-compose up` the first time (or with `--build`) will build your custom container, then run your `ENTRYPOINT` task.
+Subsequent runs of `docker-compose up` will only execute your `ENTRYPOINT` task.
 
 ### Sample `Dockerfile`
 
@@ -61,8 +65,8 @@ services:
             - ./src:/var/docs
 ```
 
-  [Docker Compose]: https://docs.docker.com/compose/
-  [Markdown]: http://commonmark.org
-  [Pandoc]: http://pandoc.org
-  [PlantUML]: http://plantuml.com
-  [reStructuredText]: http://docutils.sourceforge.net/rst.html
+[Docker Compose]: https://docs.docker.com/compose/
+[Markdown]: http://commonmark.org
+[Pandoc]: http://pandoc.org
+[PlantUML]: http://plantuml.com
+[reStructuredText]: http://docutils.sourceforge.net/rst.html

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # alpine-pandoc
 
-![MicroBadger Size (tag)](https://img.shields.io/microbadger/image-size/skyzyx/alpine-pandoc/1.1.0?style=for-the-badge)
-![MicroBadger Layers (tag)](https://img.shields.io/microbadger/layers/skyzyx/alpine-pandoc/1.1.0?style=for-the-badge)
+![MicroBadger Size (tag)](https://img.shields.io/microbadger/image-size/skyzyx/alpine-pandoc/1.2.0?style=for-the-badge)
+![MicroBadger Layers (tag)](https://img.shields.io/microbadger/layers/skyzyx/alpine-pandoc/1.2.0?style=for-the-badge)
 ![Docker Pulls](https://img.shields.io/docker/pulls/skyzyx/alpine-pandoc?style=for-the-badge)
 ![Docker Stars](https://img.shields.io/docker/stars/skyzyx/alpine-pandoc?style=for-the-badge)
 
@@ -21,7 +21,7 @@ make
 
 ## Consuming the Container
 
-The short version is `FROM skyzyx/alpine-pandoc:1.1.0`.
+The short version is `FROM skyzyx/alpine-pandoc:1.2.0`.
 
 1. Compiling Pandoc takes some time, so using this container saves you that time.
 1. Build your own container with your own specific dependencies using `RUN` commands.
@@ -34,7 +34,7 @@ Subsequent runs of `docker-compose up` will only execute your `ENTRYPOINT` task.
 ### Sample `Dockerfile`
 
 ```Dockerfile
-FROM skyzyx/alpine-pandoc:1.1.0
+FROM skyzyx/alpine-pandoc:1.2.0
 
 ENV PERSISTENT_DEPS wget git mercurial make gmp openssh sphinx
 ENV SPHINXBUILD /usr/bin/sphinx-build

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It is intended to provide an environment which is optimized for generating docum
 
 We use:
 
-* [Pandoc] (Haskell) to convert all [Markdown] into either generated HTML or [reStructuredText] files.
-* [PlantUML] (Java) to convert UML diagrams to SVG images.
+* [Pandoc] (Haskell) to convert [Markdown] into HTML, [reStructuredText] or PDF.
+* [PlantUML] (Java) to convert UML diagrams to SVG or PNG images.
 
 ## Building the Container
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ ENTRYPOINT ["make", "docs"]
 version: "3"
 services:
     documentation-builder:
-        build:
-            context: .
-            dockerfile: Dockerfile
+        build: .
         volumes:
             - ./src:/var/docs
 ```


### PR DESCRIPTION
Merging this will:
1. Refactor `README.md` to put each sentence and badge on its own line;
1. Update all version references to the latest (1.2.0);
1. Add another sample `Dockerfile`, showing a workflow based on XeTeX to convert Markdown to PDF.